### PR TITLE
Add styles for orange and light green text.

### DIFF
--- a/tool.css
+++ b/tool.css
@@ -67,6 +67,14 @@ body {
 	color: #008000
 }
 
+.orange-text {
+	color: orange
+}
+
+.light-green-text {
+	color: #99CC00;
+}
+
 .open-sans-sans-serif-text {
 	font-family: 'Open Sans', sans-serif;
 }


### PR DESCRIPTION
This is done to avoid inline styles in tool.html. See - https://softwareengineering.stackexchange.com/questions/319629/why-is-it-bad-to-use-inline-styling-in-html-for-generic-styles to know why this is considered bad practice.