### PR TITLE
Make the "Downoad MetaSUB data" card always center regardless of mini…

### DIFF
--- a/tool.css
+++ b/tool.css
@@ -9,13 +9,14 @@ body {
 
 .metasub-download{
 	background-color: lightgrey;
+  	position: absolute;
+	background-color: lightgrey;
 	position: relative;
-        left: 437px;
 	width: 300px;
-    	border: 25px solid white;
-    	padding: 25px;
+  	border: 25px solid white;
+  	padding: 25px;
 	border-radius: 25px;
-    	margin: 25px;
+  	margin: auto;
 }
 
 .heading-message {


### PR DESCRIPTION
…mization/maximization of the browser/desktop application.

**Before this PR -** 
Earlier the "Downoad MetaSUB data" card didn't change its position according to the browser's/desktop app's window size.
The screenshot below shows how the card didn't move to the center when the browser was minimized - 

![early](https://user-images.githubusercontent.com/14831291/35183248-c1a976b0-fe08-11e7-85c4-91932d84c769.GIF)

**After this PR -** 
The screenshot below shows how the card adjusts according to the browser's window size-

![after](https://user-images.githubusercontent.com/14831291/35183261-e4500b2a-fe08-11e7-90b5-c81789b6b924.GIF)
 
